### PR TITLE
Class14 - Update for Google Name changes

### DIFF
--- a/docs/class14/class14.rst
+++ b/docs/class14/class14.rst
@@ -1,4 +1,4 @@
-Deploying F5 Solutions to GCP with Terraform and The F5 Automation Toolchain
+Deploying F5 Solutions to Google Cloud with Terraform and The F5 Automation Toolchain
 ============================================================================
 
 This is a proctor led intermediate level lab.

--- a/docs/class14/class14.rst
+++ b/docs/class14/class14.rst
@@ -1,5 +1,5 @@
 Deploying F5 Solutions to Google Cloud with Terraform and The F5 Automation Toolchain
-============================================================================
+=====================================================================================
 
 This is a proctor led intermediate level lab.
 

--- a/docs/class14/module01/lab1.rst
+++ b/docs/class14/module01/lab1.rst
@@ -51,15 +51,15 @@ If you copied this command and tried to paste it into the terminal window, you w
 
 
 This will give you a link you can click on (or CMD-click) to open up a browser,
-prompting you to associate your GCP account with the gcloud command utility.
+prompting you to associate your Google account with the gcloud command utility.
 
 .. image:: ./images/GcloudAuth_tokenRequestVSCode.png
    :scale: 100%
    :alt: Gcloud auth token request 
 
-.. warning:: The GCP account you use must be identical to the user you signed
+.. warning:: The Google account you use must be identical to the user you signed
    up for Agility and signed into this account with. Otherwise you will not
-   have access to the F5 GCP Account built for this class.
+   have access to the F5 Google Cloud Account built for this class.
 
 .. image:: ./images/GcloudAuth_accountselection.png
    :scale: 75%
@@ -94,24 +94,24 @@ The pasted token will look like this:
    :alt: Gcloud token copied into VSCode
 
 Once you click "Enter," gcloud will now be able to operate against the Agility
-GCP account. The gcloud authorization will also allow Terraform to use the
-gcloud credentials to operate against GCP.
+Google Cloud account. The gcloud authorization will also allow Terraform to use the
+gcloud credentials to operate against Google Cloud.
 
-Deploy F5 VE and a complete application environment to GCP with Terraform
--------------------------------------------------------------------------
+Deploy F5 VE and a complete application environment to Google Cloud with Terraform
+----------------------------------------------------------------------------------
 
 From the Visual Studio Code Terminal, clone the github repository for this lab
 and change to the working directory.
 
 .. warning:: For a smooth ride, always invoke commands from inside the cloned
-   git repository (Agility2021_GCP_Terraform_ATC). To check you're in the right
+   git repository (f5-agility_GC_Terraform_ATC). To check you're in the right
    place, you can run the command ``pwd`` and the output should read
-   ``/home/ubuntu/projects/f5-agility_GCP_Terraform_ATC``
+   ``/home/ubuntu/projects/f5-agility_GC_Terraform_ATC``
 
 .. code-block:: bash
 
-   git clone https://github.com/f5devcentral/f5-agility_GCP_Terraform_ATC.git
-   cd f5-agility_GCP_Terraform_ATC/
+   git clone https://github.com/f5devcentral/f5-agility_GC_Terraform_ATC.git
+   cd f5-agility_GC_Terraform_ATC/
 
 .. image:: ./images/gitCloneRepoResults.png
    :scale: 75%
@@ -191,7 +191,7 @@ name, it will return that value.
    :scale: 75%
    :alt: tf output
 
-Login to GCP Console
+Login to Google Cloud App
 --------------------
 
 Click on "Firefox" under access methods (or use your own local browser if able)
@@ -201,7 +201,7 @@ you signed up for Agility with, and you just signed in to authenticate with
 
 Once your terraform apply has finished, navigate to "Compute Engine" -> "VM
 Instances" and locate your BIG-IP instances denoted by
-"studentX-Y-YYYY-f5vm0[1,2]." These are your BIG-IP units running within GCP
+"studentX-Y-YYYY-f5vm0[1,2]." These are your BIG-IP units running within Google Cloud
 
 .. warning:: We will be returning to lecture at this point of the lab. We will
    allow the BIG-IPs to start up for all students during the lecture.

--- a/docs/class14/module01/module1.rst
+++ b/docs/class14/module01/module1.rst
@@ -1,5 +1,5 @@
 Deploying F5 to Google Cloud with Terraform
-==================================
+===========================================
 
 .. toctree::
    :maxdepth: 1

--- a/docs/class14/module01/module1.rst
+++ b/docs/class14/module01/module1.rst
@@ -1,4 +1,4 @@
-Deploying F5 to GCP with Terraform
+Deploying F5 to Google Cloud with Terraform
 ==================================
 
 .. toctree::

--- a/docs/class14/module03/lab1.rst
+++ b/docs/class14/module03/lab1.rst
@@ -17,7 +17,7 @@ declaration files for rest of the lab. They are located under the
 f5-agility_GC_Terraform_ATC/ATC_Declarations folder.
 
 Connect the F5 Extension to the BIG-IPs
-------------------------------------------
+---------------------------------------
 
 The first step will be to configure the F5 Extension to connect to the two
 BIG-IPs

--- a/docs/class14/module03/lab1.rst
+++ b/docs/class14/module03/lab1.rst
@@ -3,8 +3,8 @@ Prepare the F5 Extension
 
 The rest of the lab we will be working with the F5 Automation Toolchain. This
 is a set of declarative API endpoints that you can install on top of TMOS to
-allow you to more simply manage BIG-IPs through an API. As part of the upcoming
-GCP Terraform module, these modules will be installed by default. Navigate in
+allow you to more simply manage BIG-IPs through an API. As part of the 
+Google Cloud Terraform module, these modules will be installed by default. Navigate in
 the TMUI to "iApps -> Package management LX" and you'll see four packages (The
 fifth is Service Discovery and is now a subset of AS3):
 
@@ -14,7 +14,7 @@ fifth is Service Discovery and is now a subset of AS3):
 
 The terraform apply you performed in the last step generated the necessary
 declaration files for rest of the lab. They are located under the
-f5-agility_GCP_Terraform_ATC/ATC_Declarations folder.
+f5-agility_GC_Terraform_ATC/ATC_Declarations folder.
 
 Connect the F5 Extension to the BIG-IPs
 ------------------------------------------
@@ -55,7 +55,7 @@ Do the same for big-ip 2.
 Submit Declarative Onboarding declarations
 ------------------------------------------
 
-From f5-agility_GCP_Terraform_ATC click on Lab4.1-DO under the drop down menu,
+From f5-agility_GC_Terraform_ATC click on Lab4.1-DO under the drop down menu,
 select "do_BIGIP1.json" request.
 
 .. image:: ./images/Lab4.1-DO-BIGIP1.png

--- a/docs/class14/module05/lab1.rst
+++ b/docs/class14/module05/lab1.rst
@@ -4,7 +4,7 @@ F5 Telemetry Streaming Initial Setup
 Telemetry Streaming was created to offload common metrics from the BIG-IP onto
 external monitoring/graphing utilities, including the major cloud-native
 monitoring programs. In this lab we will be sending the some basic metrics from
-the BIG-IP to Cloud Monitoring - part of GCP.
+the BIG-IP to Cloud Monitoring - part of Google Cloud.
 
 The Telemetry Streaming package has been installed as part of the base image.
 You can verify it is installed by going to iApps => Package Management LX where

--- a/docs/class14/module06/lab1.rst
+++ b/docs/class14/module06/lab1.rst
@@ -14,7 +14,7 @@ Please click on the F5 Extension icon on the left of the screen, and select bigi
    simply add your student number to the password, then you will need to update the declarations 
    to use the password that you used.  A failure to do so may result in an error.
 
-From f5-agility_GCP_Terraform_ATC/ATC_Declarations click on Lab4.3-DO_HA under the drop down
+From f5-agility_GC_Terraform_ATC/ATC_Declarations click on Lab4.3-DO_HA under the drop down
 menu, select "do_HA_BIGIP1.json" request.
 
 .. image:: ./images/Lab4.3-DO_HA-BIGIP1_PostasDO.png

--- a/docs/class14/module07/lab1.rst
+++ b/docs/class14/module07/lab1.rst
@@ -8,7 +8,7 @@ using a single REST API call rather than a set of imperative commands. The
 declaration then configures the BIG-IP system with all the required settings 
 for cloud failover. 
 
-Navigate to the GCP Compute Engine console and search for your BIG-IP1 device. It will be
+Navigate to the Google Cloud App Compute Engine and search for your BIG-IP1 device. It will be
 named studentX-Y-ZZZZ - where X is the studentID you are using for this
 lab and Y is the BIG-IP number. Select the VM instance for BIG-IP1 and then in 
 the right hand panel, select the Labels tab.
@@ -64,53 +64,53 @@ Post the declaration to BIG-IP2 as well.
 Review GCP specific configurations that Cloud Failover Extension can use
 --------------------------------------------------------------------------
 
-In your tab that has the Google CLoud Console open, in the Compute Engine,
+In your tab that has the Google Cloud App open, in the Compute Engine,
 select the VM that is BIG-IP1 and then click the three dots.  Select "View network details".
 
 .. image:: ./images/Lab4.4-AS3_CFE-BIGIP1_GCPConsoleNetworkDetails.png
    :scale: 60%
-   :alt: Google Console Network details
+   :alt: Google Cloud App Network details
 
 On this screen you should see that BIG-IP1 has Alias IP ranges assigned.
 
 .. image:: ./images/Lab4.4-AS3_CFE-BIGIP1_GCPConsoleAliasIPRanges.png
    :scale: 60%
-   :alt: Google Console Network details Alias IP ranges
+   :alt: Google Cloud App Network details Alias IP ranges
 
 When we had terraform build BIG-IP1 (this was done in the main.tf file), we defined a secondary private ip 
 on the external interface, which Google translates into Alias IP Ranges.
 
 .. image:: ./images/Lab4.4-AS3_CFE-BIGIP1_HowAliasIPRanges.png
    :scale: 100%
-   :alt: Google Console Network details Alias IP ranges
+   :alt: Google Cloud App Network details Alias IP ranges
 
-We have another Google Cloud Platform object that was created to facilitate moving traffic from one 
+We have another Google Cloud object that was created to facilitate moving traffic from one 
 device to another, a Forwarding Rule.  In your Google Console, search for load balancing.  
 
 .. image:: ./images/Lab4.4-AS3_CFE-BIGIP1_GCPConsoleLB_Navigate.png
    :scale: 60%
-   :alt: Google Console Network Load Balancing search
+   :alt: Google Cloud App Network Load Balancing search
 
 Now right click or command click and open the load balancing page in a new tab.  Once this is open, 
 click on the advanced menu option. 
 
 .. image:: ./images/Lab4.4-AS3_CFE-BIGIP1_GCPConsoleLB.png
    :scale: 60%
-   :alt: Google Console Network Load Balancing landing page
+   :alt: Google Cloud App Network Load Balancing landing page
 
 Find your student ID and you will see that there is an IP address and it is assigned to your BIGIP1.
 
 .. image:: ./images/Lab4.4-AS3_CFE-BIGIP1_GCPConsoleLBAdvanced.png
    :scale: 60%
-   :alt: Google Console Network Load Balancing advanced menu
+   :alt: Google Cloud App Network Load Balancing advanced menu
 
 We used terraform (also done in the main.tf) to build this and also defined the targets for this forwarding rule.
 
 .. image:: ./images/Lab4.4-AS3_CFE-terraform_forwarding_rule.png
    :scale: 80%
-   :alt: Google Console Network Load Balancing advanced menu
+   :alt: Google Cloud App Network Load Balancing advanced menu
 
-.. note:: Keep the two tabs with the Google console open as we will use these later.
+.. note:: Keep the two tabs with the Google Cloud App open as we will use these later.
 
 
 Test Failover
@@ -139,7 +139,7 @@ was immediately promoted to active and Big-IP1 demoted to standby.
 .. image:: ./images/Lab4.4-AS3_CFE-BIGIP2_TMUIActive.png
    :scale: 60%
 
-Now in your Google Console tabs observe what happened to the objects that you 
+Now in your Google Cloud App tabs observe what happened to the objects that you 
 looked at earlier.  Did they change? Why or why not? We will revisit this 
 later, once we have services configured.
 

--- a/docs/class14/module07/lab1.rst
+++ b/docs/class14/module07/lab1.rst
@@ -62,7 +62,7 @@ successfully posted.
 Post the declaration to BIG-IP2 as well.  
 
 Review GCP specific configurations that Cloud Failover Extension can use
---------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 In your tab that has the Google Cloud App open, in the Compute Engine,
 select the VM that is BIG-IP1 and then click the three dots.  Select "View network details".

--- a/docs/class14/module08/lab1.rst
+++ b/docs/class14/module08/lab1.rst
@@ -30,9 +30,9 @@ AS3 and Service Discovery
 --------------------------
 
 As part of AS3, you can now leverage service discovery to automatically parse
-the cloud environment to look for Metadata.  In GCP this is done via labels on
+the cloud environment to look for Metadata.  In Google Cloud this is done via labels on
 instances, or items like forwarding rules.  Review the Body of the declaration.
-The AS3 declaration is configured to discover pool members based on GCP labels.
+The AS3 declaration is configured to discover pool members based on Google Cloud labels.
 
 Log into Big-IP1 => Local Traffic => Virtual Servers. Choose the "Example01"
 Partition from the Drop-down in the upper-right-hand corner. AS3 created two
@@ -42,7 +42,7 @@ HTTP virtual servers: example01a and example01b.
    :scale: 60%
    :alt: Virtual server list Active Device
 
-Now within Big-IP1 => Local Traffic => Pools. Note "pool1". AS3 used GCP tags
+Now within Big-IP1 => Local Traffic => Pools. Note "pool1". AS3 used Google Cloud tags
 to discover and auto-populate pool1 with two web servers.
 
 .. image:: ./images/Lab4.5-AS3-BIGIP1_PoolMembers_TMUI.png

--- a/docs/class14/module09/lab1.rst
+++ b/docs/class14/module09/lab1.rst
@@ -2,13 +2,13 @@ F5 Telemetry Streaming to Google Cloud Operations Suite’s Cloud Monitoring
 ============================================================================
 
 In the previous lab, you should have generated some traffic that will 
-appear in the  GCP monitoring infrastructure.
+appear in the Google Cloud monitoring infrastructure.
 
 .. image:: ./images/webappexternal.png
    :scale: 60%
    :alt: Example app
 
-Now from the GCP Console, Services => type "Monitoring" in the search box,
+Now from the Google Cloud Console, Services => type "Monitoring" in the search box,
 choose the first "Monitoring" option from the drop-down results.
 
 .. image:: ./images/TS_GCP_MonitoringSearch.png

--- a/docs/class14/module09/lab1.rst
+++ b/docs/class14/module09/lab1.rst
@@ -1,5 +1,5 @@
 F5 Telemetry Streaming to Google Cloud Operations Suite’s Cloud Monitoring
-============================================================================
+==========================================================================
 
 In the previous lab, you should have generated some traffic that will 
 appear in the Google Cloud monitoring infrastructure.

--- a/docs/class14/module10/lab1.rst
+++ b/docs/class14/module10/lab1.rst
@@ -13,7 +13,7 @@ Terraform. To do that we'll run:
 .. image:: ./images/terraformdestroy_done.png
    :scale: 60%
 
-Go into the GCP console. You'll find that there should be no resources for your
+Go into the Google Cloud App. You'll find that there should be no resources for your
 student ID. A terraform destroy command should clean up all resources that are
 maintained in the state file.
 


### PR DESCRIPTION
Google changed the names of many components used in the class we just delivered for Agility 2022.
Lab guide and GitHub repositories have been updated to no longer use the previous terminology.

Some images used may have to be updated at a later date.