### PR TITLE
Updates for AppWorld 2024

### DIFF
--- a/docs/class13/class13.rst
+++ b/docs/class13/class13.rst
@@ -1,11 +1,11 @@
-A&O Toolchain: BIG-IP HA in Public Cloud with Terraform (Agility Labs 2023)
+A&O Toolchain: BIG-IP HA in Public Cloud with Terraform (AppWorld 2024)
 ==================================================================================
 
 .. note::
 
-   This lab relies on UDF Blueprint: **Agility 2023 - A&O BIG-IP HA in Public Cloud with Terraform**
+   This lab relies on UDF Blueprint: **AppWorld 2024 - A&O BIG-IP HA in Public Cloud with Terraform**
 
-   The code provided for this lab was tested with **BIG-IP 17.1.0.1**.
+   The code provided for this lab was tested with **BIG-IP 17.1.1.1**.
 
 |
 
@@ -24,7 +24,7 @@ In this lab, you will learn how to perform the following:
 - Deploy and test LB-based BIG-IP failover with AWS Network Load Balancer
 - Remove deployed AWS resources with Terraform
 
-Expected time to complete: **4 hours**
+Expected time to complete: **2 hours** (4 hours with optional modules)
 
 Pre-requisite: None. A basic understanding of traditional (non-cloud) BIG-IP HA configuration would be valuable, but not required.
 

--- a/docs/class13/conclusion.rst
+++ b/docs/class13/conclusion.rst
@@ -11,7 +11,7 @@ The lab environment will also shut down automatically at the end of the schedule
 
 .. attention::
 
-   Please complete the **Agility Labs Survey** and provide your feedback to help us make this lab even better.
+   Please complete the **AppWorld Labs Survey** and provide your feedback to help us make this lab even better.
 
    Thank you for participating!
 
@@ -38,6 +38,7 @@ This lab and related content would not exist without the dedication of the follo
 - Jason Chiu
 - David Fielder
 - Tony Marfil
+- Michael O'Leary
 - Anthony Ritchie
 
 |
@@ -52,6 +53,9 @@ Revision History
    * - **Version**
      - **Lead**
      - **Changes**
+   * - 4.0 (AppWorld 2024)
+     - Michael O'Leary
+     - Lab update - reduced to 2 hours but left additional hours optional
    * - 3.0 (Agility 2023)
      - Jason Chiu
      - Lab update - expanded to 4 hours of fabulous content

--- a/docs/class13/module2/lab4.rst
+++ b/docs/class13/module2/lab4.rst
@@ -280,9 +280,9 @@ The Terraform outputs include the following:
    * - bigip2_username
      - admin
    * - f5_ami_id
-     - ami-056a053acf172f5b8
+     - ami-02e15a79338c198cf
    * - f5_ami_name
-     - F5 BIGIP-17.1.0.1-0.0.4 PAYG-Adv WAF Plus 25Mbps-230407095221-3c272b55-0405-4478-a772-d0402ccf13f9
+     - F5 BIGIP-17.1.1.1-0.0.2 PAYG-Adv WAF Plus 25Mbps-231129011259-3c272b55-0405-4478-a772-d0402ccf13f9
    * - jumphost_ip
      - 52.27.102.168
    * - linux_ami_id

--- a/docs/class13/module5/module.rst
+++ b/docs/class13/module5/module.rst
@@ -1,4 +1,4 @@
-HA Failover via Cloud Load Balancer
+HA Failover via Cloud Load Balancer (Optional)
 ================================================================================
 
 In this module, you will:

--- a/docs/class13/module6/module.rst
+++ b/docs/class13/module6/module.rst
@@ -1,4 +1,4 @@
-F5 Analytics Integration with AWS
+F5 Analytics Integration with AWS (Optional)
 ================================================================================
 
 In this module, you will:


### PR DESCRIPTION
- New name (appworld) and year
- modules 5 & 6 made optional
- minor updates to reflect new AMI and bigip version